### PR TITLE
Fix sign in button state after email login

### DIFF
--- a/docs/cassia_javascript/cassia-web/components/auth/LoginForm.tsx
+++ b/docs/cassia_javascript/cassia-web/components/auth/LoginForm.tsx
@@ -64,8 +64,11 @@ export function LoginForm({ onToggleMode, onSuccess }: LoginFormProps) {
         // Don't call onSuccess for sign-up - let user see success dialog first
         // onSuccess will be called when they dismiss the success dialog
       } else {
-        await signIn(email, password)
-        onSuccess?.() // Close dialog for successful sign-in
+        const success = await signIn(email, password)
+        // Only close dialog if sign-in actually succeeded
+        if (success) {
+          onSuccess?.()
+        }
       }
     } catch (error) {
       // Error is handled by the store

--- a/docs/cassia_javascript/cassia-web/lib/stores/auth-store.ts
+++ b/docs/cassia_javascript/cassia-web/lib/stores/auth-store.ts
@@ -15,7 +15,7 @@ interface AuthState {
   userId: string | null
 
   // Auth actions
-  signIn: (email: string, password: string) => Promise<void>
+  signIn: (email: string, password: string) => Promise<boolean>
   signUp: (email: string, password: string, fullName?: string) => Promise<void>
   signInWithGoogle: () => Promise<void>
   signOut: () => Promise<void>
@@ -50,7 +50,7 @@ export const useAuthStore = create<AuthState>()(
         set({ isLoading: false, error: null, successMessage: null })
       },
       
-      signIn: async (email: string, password: string) => {
+      signIn: async (email: string, password: string): Promise<boolean> => {
         const supabase = createClient()
         set({ isLoading: true, error: null, successMessage: null })
 
@@ -72,6 +72,8 @@ export const useAuthStore = create<AuthState>()(
 
           // Load profile after successful sign in
           await get().loadProfile()
+
+          return true // Return success
         } catch (error) {
           const authError = error as AuthError
           let userFriendlyMessage = authError.message
@@ -88,6 +90,7 @@ export const useAuthStore = create<AuthState>()(
           }
 
           set({ error: userFriendlyMessage })
+          return false // Return failure
         } finally {
           set({ isLoading: false })
         }


### PR DESCRIPTION
The signIn function was not returning success/failure status, causing the login dialog to close even when authentication failed. This also meant the dialog could close before the isAuthenticated state was properly set.

Changes:
- Modified signIn() to return a boolean indicating success/failure
- Updated LoginForm to only close dialog when signIn returns true